### PR TITLE
Locatorregistered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+.idea/

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -19,24 +19,13 @@ use DeckOfCards\Infrastructure\Repositories\InMemoryDeckRepository;
 
 $decks = new InMemoryDeckRepository;
 
-$locator = new InMemoryLocator([]);
-
-$locator->addHandler(
-    new ShuffleDeckHandler($decks),
-    ShuffleDeck::class
-);
-$locator->addHandler(
-    new DrawCardHandler($decks),
-    DrawCard::class
-);
-$locator->addHandler(
-    new CreateDeckHandler($decks),
-    CreateDeck::class
-);
-
 $handlerMiddleware = new CommandHandlerMiddleware(
     new ClassNameExtractor,
-    $locator,
+    new InMemoryLocator([
+        ShuffleDeck::class  => new ShuffleDeckHandler($decks),
+        DrawCard::class     => new DrawCardHandler($decks),
+        CreateDeck::class   => new CreateDeckHandler($decks)
+    ]),
     new HandleInflector
 );
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,7 +8,31 @@ use League\Tactician\Handler\CommandHandlerMiddleware;
 use League\Tactician\Handler\MethodNameInflector\HandleInflector;
 use League\Tactician\Handler\CommandNameExtractor\ClassNameExtractor;
 
+use DeckOfCards\Application\Commands\CreateDeck;
+use DeckOfCards\Application\Commands\CreateDeckHandler;
+use DeckOfCards\Application\Commands\DrawCard;
+use DeckOfCards\Application\Commands\DrawCardHandler;
+use DeckOfCards\Application\Commands\ShuffleDeck;
+use DeckOfCards\Application\Commands\ShuffleDeckHandler;
+
+use DeckOfCards\Infrastructure\Repositories\InMemoryDeckRepository;
+
+$decks = new InMemoryDeckRepository;
+
 $locator = new InMemoryLocator([]);
+
+$locator->addHandler(
+    new ShuffleDeckHandler($decks),
+    ShuffleDeck::class
+);
+$locator->addHandler(
+    new DrawCardHandler($decks),
+    DrawCard::class
+);
+$locator->addHandler(
+    new CreateDeckHandler($decks),
+    CreateDeck::class
+);
 
 $handlerMiddleware = new CommandHandlerMiddleware(
     new ClassNameExtractor,

--- a/examples/CreateDeckExample.php
+++ b/examples/CreateDeckExample.php
@@ -2,15 +2,6 @@
 
 use DeckOfCards\Domain\DeckId;
 use DeckOfCards\Application\Commands\CreateDeck;
-use DeckOfCards\Application\Commands\CreateDeckHandler;
-use DeckOfCards\Infrastructure\Repositories\InMemoryDeckRepository;
-
-$decks = new InMemoryDeckRepository;
-
-$locator->addHandler(
-    new CreateDeckHandler($decks),
-    CreateDeck::class
-);
 
 $deckId = DeckId::generate();
 

--- a/examples/DrawCardExample.php
+++ b/examples/DrawCardExample.php
@@ -3,20 +3,11 @@
 use DeckOfCards\Domain\Deck;
 use DeckOfCards\Domain\DeckId;
 use DeckOfCards\Application\Commands\DrawCard;
-use DeckOfCards\Application\Commands\DrawCardHandler;
-use DeckOfCards\Infrastructure\Repositories\InMemoryDeckRepository;
-
-$decks = new InMemoryDeckRepository;
 
 $deckId = DeckId::generate();
 
 $decks->add(
     Deck::standard($deckId)
-);
-
-$locator->addHandler(
-    new DrawCardHandler($decks),
-    DrawCard::class
 );
 
 $card = $bus->handle(

--- a/examples/ShuffleDeckExample.php
+++ b/examples/ShuffleDeckExample.php
@@ -3,20 +3,11 @@
 use DeckOfCards\Domain\Deck;
 use DeckOfCards\Domain\DeckId;
 use DeckOfCards\Application\Commands\ShuffleDeck;
-use DeckOfCards\Application\Commands\ShuffleDeckHandler;
-use DeckOfCards\Infrastructure\Repositories\InMemoryDeckRepository;
-
-$decks = new InMemoryDeckRepository;
 
 $deckId = DeckId::generate();
 
 $decks->add(
     Deck::standard($deckId)
-);
-
-$locator->addHandler(
-    new ShuffleDeckHandler($decks),
-    ShuffleDeck::class
 );
 
 $bus->handle(


### PR DESCRIPTION
In https://www.sitepoint.com/command-buses-demystified-a-look-at-the-tactician-package/ says:

`That looks good, but there is still one problem – the InMemoryLocator needs the Handlers to be registered so they can be found at runtime. Since this is only bootstrap code for a couple of examples, let’s store a reference to the locator for now so Handlers can be registered when needed later.`

However, you can use Tactician's feature in which you can register multiple Handler in constructor.

Further, probably you will register Handlers in a provider far from the place Handler will be handle, with separated providers, for tests and production.